### PR TITLE
make it work on 1.9.3

### DIFF
--- a/lib/weixin_js_sdk/access_token.rb
+++ b/lib/weixin_js_sdk/access_token.rb
@@ -4,7 +4,7 @@ module WeixinJsSDK
 
     attr_reader :token, :expires_in
 
-    def initialize(app_id: '', app_secret: '')
+    def initialize(app_id, app_secret)
       url = URI_TEMPLATE % {
         app_id: app_id,
         app_secret: app_secret

--- a/lib/weixin_js_sdk/errors.rb
+++ b/lib/weixin_js_sdk/errors.rb
@@ -5,7 +5,7 @@ module WeixinJsSDK
     class InvalidRequest < Standard
       DOC_URI = 'http://mp.weixin.qq.com/wiki/17/fa4e1434e57290788bde25603fa2fcbd.html'.freeze
 
-      def initialize(error_code: '', message: '')
+      def initialize(error_code, message)
         @error_code = error_code
         @message = message
       end

--- a/lib/weixin_js_sdk/signature.rb
+++ b/lib/weixin_js_sdk/signature.rb
@@ -4,7 +4,7 @@ module WeixinJsSDK
   class Signature
     TEMPLATE = 'jsapi_ticket=%{jsapi_ticket}&noncestr=%{nonce_str}&timestamp=%{timestamp}&url=%{url}'.freeze
 
-    def initialize(ticket: '', nonce_str: '', timestamp: '', url: '')
+    def initialize(ticket, nonce_str, timestamp, url)
       @ticket = ticket
       @nonce_str = nonce_str
       @timestamp = timestamp

--- a/lib/weixin_js_sdk/ticket.rb
+++ b/lib/weixin_js_sdk/ticket.rb
@@ -4,7 +4,7 @@ module WeixinJsSDK
 
     attr_reader :token, :expires_in
 
-    def initialize(access_token: '')
+    def initialize(access_token)
       url = URI_TEMPLATE % {
         access_token: access_token
       }


### PR DESCRIPTION
make it work on 1.9.3 by simply removing default value of parameter.  

as I need put it on a 1.9.3 environment ( quite old box which has old dependency and lots of php stuff/dependencies, make it hard to compile ruby gems rightly  or upgrade)

it might be useless as 1.9.x is out of maintenance, but fire this anyway for your adjustment..
